### PR TITLE
Added: Autosort capability to public API

### DIFF
--- a/src/Bannerlord.LauncherManager/LauncherManagerHandler.Sorter.cs
+++ b/src/Bannerlord.LauncherManager/LauncherManagerHandler.Sorter.cs
@@ -20,19 +20,9 @@ partial class LauncherManagerHandler
     /// </summary>
     public void Sort()
     {
-        static IEnumerable<ModuleInfoExtended> Sort(IEnumerable<ModuleInfoExtended> source)
-        {
-            var orderedModules = source
-                .OrderByDescending(x => x.IsOfficial)
-                .ThenBy(x => x.Id, new AlphanumComparatorFast())
-                .ToArray();
-
-            return ModuleSorter.TopologySort(orderedModules, module => ModuleUtilities.GetDependencies(orderedModules, module));
-        }
-
         IsSorting = true;
         var modules = GetModuleViewModels()?.Select(x => x.ModuleInfoExtended) ?? [];
-        var sorted = Sort(modules);
+        var sorted = SortHelper.AutoSort(modules);
         var sortedViewModels = GetViewModelsFromModules(sorted);
         SetModuleViewModels(sortedViewModels);
 

--- a/src/Bannerlord.LauncherManager/Utils/SortHelper.cs
+++ b/src/Bannerlord.LauncherManager/Utils/SortHelper.cs
@@ -10,6 +10,20 @@ namespace Bannerlord.LauncherManager.Utils;
 public static class SortHelper
 {
     /// <summary>
+    /// Given a list of modules provided as <paramref name="source"/>, automatically
+    /// sorts the modules such that they form a valid load order based on module metadata.
+    /// </summary>
+    public static IEnumerable<ModuleInfoExtended> AutoSort(IEnumerable<ModuleInfoExtended> source)
+    {
+        var orderedModules = source
+            .OrderByDescending(x => x.IsOfficial)
+            .ThenBy(x => x.Id, new AlphanumComparatorFast())
+            .ToArray();
+
+        return ModuleSorter.TopologySort(orderedModules, module => ModuleUtilities.GetDependencies(orderedModules, module));
+    }
+    
+    /// <summary>
     /// External<br/>
     /// </summary>
     public static void ToggleModuleSelection<TModuleViewModel>(IEnumerable<TModuleViewModel> moduleVMs, IDictionary<string, TModuleViewModel> lookup, TModuleViewModel moduleVM)


### PR DESCRIPTION
This adds the ability to Autosort to public API.

Previously this was only accessible via the LauncherManager , but not for users who wished to call it without providing the full LauncherManager abstraction.

This commit makes that functionality visible now.